### PR TITLE
rewrite react-redux connect then implement react-redux library

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
         <script crossorigin src='https://unpkg.com/babel-standalone@6.15.0/babel.min.js' type='text/javascript'></script>
         <script crossorigin src='https://unpkg.com/redux@4.0.4/dist/redux.js' type='text/javascript'></script>
         <script crossorigin src='https://unpkg.com/redux-thunk@2.2.0/dist/redux-thunk.min.js' type='text/javascript'></script>
+        <script crossorigin src='https://unpkg.com/react-redux@7.1.1/dist/react-redux.js' type='text/javascript'></script>
         <script src='api.js' type='text/javascript'></script>
     </head>
 

--- a/react-code.js
+++ b/react-code.js
@@ -116,19 +116,21 @@ class App extends React.Component {
   }
 }
 
+// *****************************************************************************
+// connect react to redux store in efficient way
 const Context = React.createContext()
+// // used to provide the store via react Context.  Wrap top-level of app to make available
+// class Provider extends React.Component {
+//   render () {
+//     return (
+//       <Context.Provider value={this.props.store}>
+//         {this.props.children}
+//       </Context.Provider>
+//     )
+//   }
+// }
 
-// used to provide the store via react Context.  Wrap top-level of app to make available
-class Provider extends React.Component {
-  render () {
-    return (
-      <Context.Provider value={this.props.store}>
-        {this.props.children}
-      </Context.Provider>
-    )
-  }
-}
-// **************************************************************
+// *****************************************************************************
 // Handrolled connect function
 // Goal -- Render any component, passing that component any data it needs from the store
 
@@ -145,58 +147,58 @@ class Provider extends React.Component {
 //   loading: state.loading
 // }))(App)
 
-function connect (mapStateToProps) {
-  return (Component) => {
-    class Receiver extends React.Component {
-      componentDidMount () {
-        const { subscribe } = this.props.store
+// function connect (mapStateToProps) {
+//   return (Component) => {
+//     class Receiver extends React.Component {
+//       componentDidMount () {
+//         const { subscribe } = this.props.store
+//
+//         this.unsubscribe = subscribe(() => this.forceUpdate())
+//       }
+//
+//       componentWillUnmount () {
+//         this.unsubscribe()
+//       }
+//
+//       render () {
+//         const { dispatch, getState } = this.props.store
+//         const state = getState()
+//         const stateNeeded = mapStateToProps(state)
+//         return <Component {...stateNeeded} dispatch={dispatch} />
+//       }
+//     }
+//
+//     class ConnectedComponent extends React.Component {
+//       render () {
+//         return (
+//           <Context.Consumer>
+//             {(store) => <Receiver store={store}/> }
+//           </Context.Consumer>
+//         )
+//       }
+//     }
+//
+//     return ConnectedComponent
+//   }
+// }
 
-        this.unsubscribe = subscribe(() => this.forceUpdate())
-      }
-
-      componentWillUnmount () {
-        this.unsubscribe()
-      }
-
-      render () {
-        const { dispatch, getState } = this.props.store
-        const state = getState()
-        const stateNeeded = mapStateToProps(state)
-        return <Component {...stateNeeded} dispatch={dispatch} />
-      }
-    }
-
-    class ConnectedComponent extends React.Component {
-      render () {
-        return (
-          <Context.Consumer>
-            {(store) => <Receiver store={store}/> }
-          </Context.Consumer>
-        )
-      }
-    }
-
-    return ConnectedComponent
-  }
-}
-
-const ConnectedApp = connect((state) => ({
+const ConnectedApp = ReactRedux.connect((state) => ({
     loading: state.loading
 }))(App)
 
-const ConnectedTodos = connect((state) => ({
+const ConnectedTodos = ReactRedux.connect((state) => ({
   todos: state.todos
 }))(Todos)
 
-const ConnectedGoals = connect((state) => ({
+const ConnectedGoals = ReactRedux.connect((state) => ({
   goals: state.goals
 }))(Goals)
 
 
 
 ReactDOM.render(
-  <Provider store={store}>
+  <ReactRedux.Provider store={store}>
     <ConnectedApp />
-  </Provider>,
+  </ReactRedux.Provider>,
   document.getElementById('app')
 )

--- a/react-code.js
+++ b/react-code.js
@@ -20,18 +20,18 @@ function List ( props ) {
 class Todos extends React.Component {
   addTodo = (e) => {
     e.preventDefault()
-    this.props.store.dispatch(handleAddTodo(
+    this.props.dispatch(handleAddTodo(
       this.input.value,
       () => this.input.value = ''
     ))
   }
 
   removeTodo = (todo) => {
-    this.props.store.dispatch(handleRemoveTodo(todo))
+    this.props.dispatch(handleRemoveTodo(todo))
   }
 
   toggleTodo = (todo) => {
-    this.props.store.dispatch(handleToggleTodo(todo.id))
+    this.props.dispatch(handleToggleTodo(todo.id))
   }
 
   render() {
@@ -58,14 +58,14 @@ class Todos extends React.Component {
 class Goals extends React.Component {
   addGoal = (e) => {
     e.preventDefault()
-    this.props.store.dispatch(handleAddGoal(
+    this.props.dispatch(handleAddGoal(
       this.input.value,
       () => this.input.value = ''
     ))
   }
 
   removeGoal = (goal) => {
-    this.props.store.dispatch(handleRemoveGoal(goal))
+    this.props.dispatch(handleRemoveGoal(goal))
   }
 
   render() {
@@ -106,8 +106,7 @@ class App extends React.Component {
   }
 
   render () {
-    const { store } = this.props
-    const { todos, goals, loading } = store.getState()
+    const { loading } = this.props.store.getState()
 
     if (loading) {
       return <Loading />
@@ -115,14 +114,66 @@ class App extends React.Component {
 
     return (
       <div>
-        <Todos store={store} todos={todos} />
-        <Goals store={store} goals={goals} />
+        <ConnectedTodos />
+        <ConnectedGoals />
       </div>
     )
   }
 }
 
+const Context = React.createContext()
+
+class Provider extends React.Component {
+  render () {
+    return (
+      <Context.Provider value={this.props.store}>
+        {this.props.children}
+      </Context.Provider>
+    )
+  }
+}
+
+class ConnectedApp extends React.Component {
+  render () {
+    return (
+      <Context.Consumer>
+        {(store) => (
+          <App store={store} />
+        )}
+      </Context.Consumer>
+    )
+  }
+}
+
+class ConnectedTodos extends React.Component {
+  render () {
+    return (
+      <Context.Consumer>
+        {(store) => {
+          const { todos } = store.getState()
+          return <Todos todos={todos} dispatch={store.dispatch} />
+        }}
+      </Context.Consumer>
+    )
+  }
+}
+
+class ConnectedGoals extends React.Component {
+  render () {
+    return (
+      <Context.Consumer>
+        {(store) => {
+          const { goals } = store.getState()
+          return <Goals goals={goals} dispatch={store.dispatch} />
+        }}
+      </Context.Consumer>
+    )
+  }
+}
+
 ReactDOM.render(
-  <App store={store}/>,
+  <Provider store={store}>
+    <ConnectedApp />
+  </Provider>,
   document.getElementById('app')
 )


### PR DESCRIPTION
added in react-redux library to efficiently pipe state to the components and limit nesting / overall re-rendering of the app

dove deep into the innerworkings of the connect function and rebuilt it to demonstrate understanding

implements a higher-order component based wrapper using context.provide / consume

rewrote and implemented connect function

scrapped all of the above and installed react-redux library